### PR TITLE
feat: support webpack 2

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,8 +18,8 @@ module.exports = function loader(content) {
 
   const lang = Prism.languages[query.lang];
 
-  this.value = Prism.highlight(content, lang);
-  const str = JSON.stringify(this.value);
+  const value = Prism.highlight(content, lang);
+  const str = JSON.stringify(value);
 
   return `module.exports = ${str}`;
 };


### PR DESCRIPTION
When using this loader with the latest beta of Webpack 2 (2.1.0-beta.22), I'm getting this error:
`Module build failed: TypeError: Can't add property value, object is not extensible`

The changes of this PR solve the issue, and seems to still work fine in Webpack 1.

(Note that I'm not very familiar with Webpack.)
