### PR TITLE
Use loader-util's getOptions

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const Prism = require('prismjs');
 const loaderUtils = require('loader-utils');
 
 module.exports = function loader(content) {
-  const query = loaderUtils.parseQuery(this.query);
+  const query = loaderUtils.getOptions(this);
 
   if (!query.lang) {
     throw new Error('You need to provide `lang` query parameter');

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/valor-software/prismjs-loader#readme",
   "dependencies": {
-    "loader-utils": "0.2.14",
+    "loader-utils": "^1.1.0",
     "prismjs": "1.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
I was attempting to use `prismjs-loader` in a Webpack config file and could not because `this.query` was an object, not a string. `loader-utils` has been updated to include a `getOptions` function which can handle either objects or strings.